### PR TITLE
Writes deployed URL to a file whose name is passed as args

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,14 @@ and update the pull request with the staging URL:
 
 Clicking on the "Details" link will open the page to the staging deployment URL.
 
+If you want to get the staging URL in subsequent steps of your Travis build, e.g running a [lighthouse-ci](https://github.com/ebidel/lighthouse-ci) test on the stage build, you can instruct `now-travis` to write the URL in a file by passing a `file` argument with the name of the file.
+
+```yaml
+  - NOW_ALIAS=myalias.com node_modules/.bin/now-travis --file=now-staging-url
+```
+
+With this, the staging URL will be written to a file named `now-staging-url`.
+
 When pushing commits to master, now-travis will deploy the build to ∆ Now and alias the deployment using the value specified
 in the `NOW_ALIAS` environment variable. This environment variable is only used on pushes, not pull requests.
 

--- a/bin/now-travis
+++ b/bin/now-travis
@@ -5,8 +5,12 @@ const normalizeUrl = require('normalize-url');
 const spawn = require('cross-spawn');
 const travisAfterAll = require('travis-after-all');
 const urlRegex = require('url-regex');
-
+const fs = require('fs');
 const nowCli = require.resolve('now/bin/now');
+
+const argv = require('yargs').argv;
+// should the URL be written to a file?
+const writeURL = argv.file; // this will be the filename
 
 if (!process.env.CI || !process.env.TRAVIS) {
   throw new Error('Could not detect Travis CI environment');
@@ -69,6 +73,8 @@ function deploy(context, sha) {
 
   child.on('close', () => {
     const target_url = alias || getUrl(stdout);
+    if (writeURL) fs.writeFileSync(writeURL, target_url);
+    // deployment is now complete
 
     ghRepo.status(sha, {
       context,

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "now": "^2.0.3",
     "octonode": "^0.7.8",
     "travis-after-all": "^1.4.4",
-    "url-regex": "^4.0.0"
+    "url-regex": "^4.0.0",
+    "yargs": "^8.0.2"
   }
 }


### PR DESCRIPTION
This addresses #6.

I wanted the stage URL to be available after this script runs to enable other subsequent scripts to make use of it, e.g. `lighthouse-ci`

I tried by setting some env variables but they seem to be immutable for one build. So I'm simply writing the url to a file whose name is passed via args.

Let me know if you want to add this feature.